### PR TITLE
Adding the ability to specify specific API versions when communicatin…

### DIFF
--- a/paperlessngx_postprocessor.py
+++ b/paperlessngx_postprocessor.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import yaml
 import os
+import copy
 
 from paperlessngx_postprocessor import Config, PaperlessAPI, Postprocessor
 
@@ -45,7 +46,12 @@ if __name__ == "__main__":
 
     logger = logging.getLogger("paperlessngx_postprocessor")
     logger.setLevel(config["verbose"])
-    logger.debug(f"Running {sys.argv[0]} with config {config} and {selector_config}")
+    # If we're in debug mode, sanitize the config to not print auth tokens
+    if logger.level <= logging.DEBUG:
+        sanitized_config = copy.deepcopy(config)
+        if sanitized_config['auth_token'] is not None:
+            sanitized_config['auth_token'] = "XXXXXXXX"
+        logger.debug(f"Running {sys.argv[0]} with config {sanitized_config} and {selector_config}")
 
     # if config["selector"] != "all" and config["item_id_or_name"] is None:
     #     if config["selector"] == "restore":

--- a/paperlessngx_postprocessor/config.py
+++ b/paperlessngx_postprocessor/config.py
@@ -146,6 +146,10 @@ class Config:
         self._fix_options()
         
     def _fix_options(self):
+        # Check if the environment variable PAPERLESS_DEBUG is true, and if so, force debug verbosity
+        # This is how it's checked in paperless-ngx, see https://github.com/paperless-ngx/paperless-ngx/blob/246f17c6c85ee0d4958e5c6e99f77007a050839c/src/paperless/settings.py#L42
+        if bool(os.environ.get("PAPERLESS_DEBUG", "NO").lower() in ("yes", "y", "1", "t", "true")):
+            self._options["verbose"] = "DEBUG"
         if isinstance(self._options.get("dry_run"), str):
             if self._options["dry_run"].lower() in ["f", "false", "no"]:
                 self._options["dry_run"] = False


### PR DESCRIPTION
…g with the paperless-ngx API. By default, we currently use 3; we'll need to increase that number as we add new features like supporting custom fields.

Also some general debugging cleanup: sanitizing auth tokens from debug logs, and logging API errors more clearly with HTTP response.