### PR TITLE
Apparently the change in paperless-ngx 2.16 makes it so that when spe…

### DIFF
--- a/paperlessngx_postprocessor/paperless_api.py
+++ b/paperlessngx_postprocessor/paperless_api.py
@@ -209,7 +209,7 @@ class PaperlessAPI:
         result["archive_serial_number"] = metadata_in_filename_format["asn"]
         result["tags"] = [self.get_item_id_by_name("tags", tag_name) for tag_name in metadata_in_filename_format["tag_list"]]
         result["title"] = metadata_in_filename_format["title"]
-        result["created"] = metadata_in_filename_format["created"]
+        #result["created"] = metadata_in_filename_format["created"]
         result["created_date"] = dateutil.parser.isoparse(metadata_in_filename_format["created"]).strftime("%F")
         result["added"] = metadata_in_filename_format["added"]
         


### PR DESCRIPTION
…cifying an earlier version of the REST API, you can no longer change the `created` field--only the `created_date` field. That's weird, since with 2.16+ you're only allowed to change `created` and *not* `created_date`.

Either way, the solution for now is to stick with the older REST API and just not try to change the `created` field; changes will still go through via the `created_date` field.