### PR TITLE
Adds support to process custom fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea

--- a/paperlessngx_postprocessor/paperless_api.py
+++ b/paperlessngx_postprocessor/paperless_api.py
@@ -28,6 +28,7 @@ class PaperlessAPI:
         self._paperless_api_version = 3
 
         self._common_headers = {"Authorization": f"Token {self._auth_token}",
+                                "Content-Type": "application/json",
                                 "Accept": f"application/json; version={self._paperless_api_version}"}
 
     def _get_custom_fields(self):
@@ -109,7 +110,7 @@ class PaperlessAPI:
     def patch_document(self, document_id, data):
         response = requests.patch(f"{self._api_url}/documents/{document_id}/",
                                   headers = self._common_headers,
-                                  data = data)
+                                  json = data)
         if not response.ok:
             self._log_request_error(response)
         return response

--- a/rulesets.d/example.yml
+++ b/rulesets.d/example.yml
@@ -25,3 +25,11 @@ Parse creation date from filename:
     created_month: '{{ title_old | regex_sub("^(?P<created_year>\d{4})-(?P<created_month>\d{2})-(?P<created_day>\d{2}) (?P<title>.*)$", "\g<created_month>") }}'
     created_day:   '{{ title_old | regex_sub("^(?P<created_year>\d{4})-(?P<created_month>\d{2})-(?P<created_day>\d{2}) (?P<title>.*)$", "\g<created_day>") }}'
   validation_rule: '{{ num_documents(correspondent=correspondent, document_type=document_type, created_date_object=created_date_object) == 1 }}'
+---
+Ruleset for Custom Field:
+  match: True
+  metadata_regex: 'Eingegangen (?P<entry_day>\d{1,2}).(?P<entry_month>\d{1,2}).(?P<entry_year>\d{4})'
+  metadata_postprocessing:
+    title: "Test Custom Fields Functionality"
+    custom_fields:
+      Eingegangen: '{{entry_year}}-{{entry_month}}-{{entry_day}}'


### PR DESCRIPTION
This PR adds support to process custom fields by following ruleset

```yaml
Ruleset for Custom Field:
  match: True
  metadata_regex: 'Eingegangen (?P<entry_day>\d{1,2}).(?P<entry_month>\d{1,2}).(?P<entry_year>\d{4})'
  metadata_postprocessing:
    title: "Test Custom Fields Functionality"
    custom_fields:
      Eingegangen: '{{entry_year}}-{{entry_month}}-{{entry_day}}'
```

This ruleset will add a custom field named `Eingegangen` with content matched by `metadata_regex`.